### PR TITLE
Fix problem with in ($coloumns) of

### DIFF
--- a/fields/field.addresslocation.php
+++ b/fields/field.addresslocation.php
@@ -302,13 +302,17 @@
 			$data = join(',', $data);
 
 			if(preg_match("/^in ($columns) of (.+)$/", $data, $filters)){
+				$field_id = $this->get('id');
+
 				$column = $columns_to_labels[$filters[1]];
 				$value = $filters[2];
 				
 				$where .= " AND (
-					t{$this->get('id')}_{$this->_key}.{$column} = '{$value}'
-					OR t{$this->get('id')}_{$this->_key}.{$column}_handle = '{$value}'
+					t{$field_id}_{$this->_key}.{$column} = '{$value}'
+					OR t{$field_id}_{$this->_key}.{$column}_handle = '{$value}'
 				)";
+
+				$joins .= " LEFT JOIN `tbl_entries_data_{$field_id}` AS `t{$field_id}_{$this->_key}` ON (`e`.`id` = `t{$field_id}_{$this->_key}`.entry_id) ";
 			}
 			/*
 			within 20 km of 10.545, -103.1


### PR DESCRIPTION
Running a filter `in city of London` was returning an SQL error saying `t1_1.city`
is not defined. This should fix the problem by adding the join statement at the end
similar to what is done to the `within` statement.

I also took the freedom to edit another two lines. Looking at the code you could probably externalize $field_id and probably the $joins statement if made coherent with the other-one but I did not want to change your code structure & table names.
